### PR TITLE
chore: make npm ci optional and production-only where applicable (Rai…

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -13,20 +13,21 @@ WORKDIR /app
 
 # Copy root package files
 COPY package*.json ./
-RUN npm ci --only=production
+# Production install with lockfile optional and modern flags
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
 
 # Backend build stage
 FROM base as backend
 WORKDIR /app/backend
 COPY backendUploader/package*.json ./
-RUN npm ci --only=production
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
 COPY backendUploader/ ./
 
 # Frontend build stage  
 FROM base as frontend
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
-RUN npm ci
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 COPY frontend/ ./
 # Explicitly specify Vite version for build
 RUN npx --yes vite@5.4.19 build
@@ -35,7 +36,7 @@ RUN npx --yes vite@5.4.19 build
 FROM base as worker
 WORKDIR /app/worker
 COPY processing-storage/package*.json ./
-RUN npm ci --only=production
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
 COPY processing-storage/ ./
 
 # Final production image


### PR DESCRIPTION
…lway + frontend)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Make the use of `npm ci` optional and production-only by checking for the presence of `package-lock.json` and using `npm install` with modern flags as a fallback in the Docker build process.

### Why are these changes being made?

This change optimizes the Docker build process by utilizing the faster `npm ci` when a lockfile is present and falling back to `npm install` when it is not, ensuring flexibility and reducing potential build errors. The inclusion of the `--omit=dev` flag for production installations helps minimize the final image size by excluding unnecessary development dependencies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->